### PR TITLE
Fixes Geonames file format error

### DIFF
--- a/countries_plus/migrations/0005_auto_20160224_1804.py
+++ b/countries_plus/migrations/0005_auto_20160224_1804.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('countries_plus', '0004_auto_20150616_1242'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='country',
+            name='area',
+            field=models.DecimalField(null=True, max_digits=11, decimal_places=2, blank=True),
+        ),
+    ]

--- a/countries_plus/models.py
+++ b/countries_plus/models.py
@@ -40,7 +40,7 @@ class Country(models.Model):
     fips = models.CharField(max_length=3, blank=True, null=True)
     name = models.CharField(max_length=255, unique=True)
     capital = models.CharField(max_length=255, blank=True, null=True)
-    area = models.DecimalField(max_digits=9, decimal_places=1, blank=True, null=True)
+    area = models.DecimalField(max_digits=11, decimal_places=2, blank=True, null=True)
     population = models.IntegerField(blank=True, null=True)
     continent = models.CharField(max_length=2, blank=True, null=True)
     tld = models.CharField(max_length=255, blank=True, null=True)


### PR DESCRIPTION
The bugs occurred when countries had the area field filled with values with more than 1 decimal case (i.e.: Monaco) or the area string was bigger than 7 characters (e.g.: Antarctica).

The fix comprises of updating the models.py and adding a new migration.