### PR TITLE
Support for Django 1.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "*"
 django = [
-    {version = "<=1.11", python = "^2.7"},
+    {version = "<2", python = "^2.7"},
     {version = ">=2", python = "^3.6"}
 ]
 six = "*"


### PR DESCRIPTION
the condition {version = "<1.11", python = "^2.7"} removes support for the more recent versions of django 1.11 (the latest is 1.11.27)
1.11.27 > 1.11