### PR TITLE
Prevent empty string indexing when parsing Geonames data

### DIFF
--- a/countries_plus/utils.py
+++ b/countries_plus/utils.py
@@ -232,6 +232,8 @@ def parse_geonames_data(lines_iterator):
     num_updated = 0
     for line in lines_iterator:
         line = line.decode()
+        if len(line) == 0:
+            continue
         if line[0] == "#":
             if line[0:4] == "#ISO":
                 data_headers = line.strip('# ').split('\t')


### PR DESCRIPTION
A recent change to the Geonames text file (http://download.geonames.org/export/dump/countryInfo.txt) introduced an empty string when attempting to parse it. This introduces an `IndexError` in the line `if line[0] == "#": ...`.

Added a line to handle empty strings.