### PR TITLE
Change gettext to gettext_lazy on module level

### DIFF
--- a/countries_plus/models.py
+++ b/countries_plus/models.py
@@ -3,7 +3,7 @@ import logging
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This was causing problems with Django 5.0, raising the Exception:

```
AppRegistryNotReady: The translation infrastructure cannot be initialized before the apps registry is ready. Check that you don't make non-lazy gettext calls at import time.
```

Fixes #28 